### PR TITLE
Suspend computer after finish

### DIFF
--- a/locale/en/LC_MESSAGES/curlew.po
+++ b/locale/en/LC_MESSAGES/curlew.po
@@ -296,6 +296,9 @@ msgstr ""
 msgid "Shutdown computer after finish"
 msgstr ""
 
+msgid "Suspend computer after finish"
+msgstr ""
+
 #: /media/DATA2/Projects/Python-Projects/curlew/Curlew/curlew.py:599
 msgid "Do you want to quit Curlew and abort conversion process?"
 msgstr ""


### PR DESCRIPTION
Hello Fayssal,
there is suspend computer after finish patch.

The suspend method is slightly different from your shutdown method, but this one works for me on fedora 17-64 with no root privileges and updated shutdown call with action to suspend does not work because of some access rights.

There is also added record in english resource file. Other resource files seems strange and incomplete to me, so I didn't add line into _ar_ and _fr_ translation files.

The state of suspend switch is not saved into curlew.cfg on purpose. I think that it's dangerous to save such settings because users could unintentionally shutdown their machine.. 

Best regards,
a.
