### PR TITLE
sync filesystem before suspend

### DIFF
--- a/Curlew/curlew.py
+++ b/Curlew/curlew.py
@@ -2128,7 +2128,7 @@ abort conversion process?'),
         self.label_details.set_markup(_('<span foreground="red" weight="bold">System will shutdown after {} sec.</span>').format(self.counter))
         self.counter -= 1
         if self.counter < 0:
-            cmd = 'dbus-send --system --print-reply --system --dest=org.freedesktop.ConsoleKit /org/freedesktop/ConsoleKit/Manager org.freedesktop.ConsoleKit.Manager.Stop'
+            cmd = 'dbus-send --system --print-reply --dest=org.freedesktop.ConsoleKit /org/freedesktop/ConsoleKit/Manager org.freedesktop.ConsoleKit.Manager.Stop'
             call(cmd, shell=True)
             return False
         return True
@@ -2144,7 +2144,7 @@ abort conversion process?'),
             self.label_details.set_text('')
             cmd = 'sync'
             call(cmd, shell=True)
-            cmd = 'dbus-send --system --print-reply --system --dest=org.freedesktop.UPower /org/freedesktop/UPower org.freedesktop.UPower.Suspend'
+            cmd = 'dbus-send --system --print-reply --dest=org.freedesktop.UPower /org/freedesktop/UPower org.freedesktop.UPower.Suspend'
             call(cmd, shell=True)
             return False
         return True


### PR DESCRIPTION
1) syncing file system before going to suspend may be good idea - it could save file system if the external device is accidentally unplugged when computer is in suspended state.

2) dbus command parameter '--system' was used twice within one call, just removed the second occurence
