### PR TITLE
fix: vob files are not supported

### DIFF
--- a/modules/curlew.py
+++ b/modules/curlew.py
@@ -1206,10 +1206,11 @@ class Curlew(Gtk.ApplicationWindow):
         file_name = ''
         wait_dlg = WaitDialog(self)
         tot = len(files)
-        
+
         mimetypes.add_type('video/realmedia', '.rmvb')
+        mimetypes.add_type('video/mpeg', '.VOB')
         for file_name in files:
-            mime = mimetypes.guess_type(file_name)[0]  
+            mime = mimetypes.guess_type(file_name)[0]
             if mime != None:
                 if 'video/' in mime or 'audio/' in mime:
 


### PR DESCRIPTION
vob files(present in video DVDs) are not recognized by the mimetypes module. Added the vob mimetype definitions to the curlew. 